### PR TITLE
don't log SecurityGateRejectionException when failOnError=false

### DIFF
--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/AbstractDependencyTrackMojo.java
@@ -83,8 +83,12 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 			if (failOnError) {
 				throw new MojoExecutionException("Error during plugin execution", e);
 			} else {
-				getLog().warn("failOnError: false => logging exception");
-				getLog().warn("Error during plugin execution", e);
+				if (e instanceof SecurityGateRejectionException) {
+					getLog().warn(e.getMessage());
+				} else {
+					getLog().warn("Error during plugin execution", e);
+				}
+				getLog().info("failOnError: false => Not failing the build");
 			}
 		}
 	}


### PR DESCRIPTION
Only print the `SecurityGateRejectionException` message, not the whole exception incl stacktrace for better readability in logs.

Don't really like the nested `if..else`, but should still be easy enough to understand?!
Maybe it'd be better catch the `SecurityGateRejectionException` right where the `securityGate.applyOn` call is made?