### PR TITLE
add missing vulnerability properties 'title' and 'subTitle'

### DIFF
--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
@@ -13,6 +13,10 @@ public class Vulnerability {
 
 	private String vulnId;
 
+	private String title;
+
+	private String subTitle;
+
 	private Severity severity;
 
 	private int severityRank;

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
@@ -15,7 +15,7 @@ public class Vulnerability {
 
 	private String title;
 
-	private String subTitle;
+	private String subtitle;
 
 	private Severity severity;
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Vulnerability.java
@@ -15,7 +15,7 @@ public class Vulnerability {
 
 	private String title;
 
-	private String subtitle;
+	private String subTitle;
 
 	private Severity severity;
 


### PR DESCRIPTION
Getting following error message when trying to upload bom with npm dependencies:
![dependency_plugin_bug](https://user-images.githubusercontent.com/45362697/73748061-fb7a1e80-4758-11ea-92f7-69e7ecb3dc91.PNG)

Seems like the fields "title" and "subTitle" are missing.
