### PR TITLE
implemented skipping of the plugin execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ These parameters are required to configure the plugin:
 - `dependencyTrackUrl`: The URL where Dependency-Track is hosted.
 - `dependencyTrackApiKey`: The API Key for Dependency-Track.
 
+Further you skip the plugin execution with the following configuration:
+
+- `skip`: a boolean value indicating if the plugin should be executed for the current project.
+
 The API Key should have sufficient permissions depending on the performed action:
 
 | Permission                | Description                                                |
@@ -292,6 +296,7 @@ Here are all the main configuration parameters summarized:
 |------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | `dependencyTrackUrl`         | The URL of the Dependency-Track Server                   |                                                                                                          |
 | `dependencyTrackApiKey`      | An API key for Dependency-Track                          |                                                                                                          |
+| `skip`                       | Skip plugin execution for the current project            | `false`                                                                                                  |
 | `failOnError`                | Whether errors should fail the build                     | `true`                                                                                                   |
 | `logPayloads`                | Whether the plugin should log request/response payloads  | `false`                                                                                                  |
 | `projectName`                | The unique name of the porject in Dependency-Track       | `${project.groupId}.${project.artifactId}`                                                               |

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/AbstractDependencyTrackMojo.java
@@ -83,10 +83,17 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 	@Parameter(property = "logPayloads", defaultValue = "false", required = false)
 	private boolean logPayloads;
 
+	@Parameter(property = "skip", defaultValue = "false", required = false)
+	private boolean skip;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		logConfiguration();
 		logGoalConfiguration();
+		if(skip) {
+			getLog().info("skip is '"+ skip +"' so skipping plugin execution.");
+			return;
+		}
 
 		try {
 			DTrackClient client = new DTrackClient(dependencyTrackUrl, dependencyTrackApiKey, getLog());
@@ -142,5 +149,6 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 		getLog().info("DependencyTrack URL             : " + dependencyTrackUrl);
 		getLog().info("Project name                    : " + projectName);
 		getLog().info("Project version                 : " + projectVersion);
+		getLog().info("Skip                            : " + skip);
 	}
 }


### PR DESCRIPTION
Hey @iabudiab,

this one is another small improvement for your plugin. It allows you to skip the plugin execution. This is useful for multi module projects where you have some modules that does not have any dependencies. For these, the plugin execution will fail because the bom is empty. So you can easily skip the execution for those modules with this configuration:

> 
             <plugins>
			<!-- skip the execution for this particular module since it has no dependencies -->
			<plugin>
				<groupId>dev.iabudiab</groupId>
				<artifactId>dependency-track-maven-plugin</artifactId>
				<!-- not apply this configuration to this modules children -->
				<inherited>false</inherited>
				<configuration>
					<skip>true</skip>
				</configuration>
			</plugin>
		</plugins>