### PR TITLE
Show unnecessary suppressions when report is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,22 +185,22 @@ This goal polls Dependency-Track for `tokenPollingDuration`, which defaults to `
 
 Configuration:
 
-| Parameter                    | Description                                                                               | Default Value                                                                 |
-|------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| `projectName`                | The unique name of the porject in Dependency-Track                                        | `${project.groupId}.${project.artifactId}`                                    |
-| `projectVersion`             | The version of the project in Dependency-Track                                            | `${project.version}`                                                          |
-| `artifactDir`                | The directory of the artifact to upload                                                   | `${project.build.directory}`                                                  |
-| `artifactName`               | The name of the artifact to upload                                                        | `bom.xml`                                                                     |
-| `pollToken`                  | Whether to poll the pending token for processing or not                                   | `true`                                                                        |
-| `tokenFile`                  | The file path into which the token will be written                                        | `${project.build.directory}/dependency-track/pendingToken`                    |
-| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.                                               | `60` seconds                                                                  |
-| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                                       | `5` seconds                                                                   |
-| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                                      | `3` times <br/>                                                               |
-| `securityGate`               | The security gate configuration                                                           | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
-| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                                            | `false`                                                                       |
-| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                                      | `true`                                                                        |
-| `cleanupSuppressions`        | Whether to generate a cleaned up suppressions file without unnecessary suppressions <br/> | `true`     <br/> <br/> <br/> <br/> <br/> <br/> <br/>                          |
-| `cleanupSuppressionsFile`    | The file path into which the suppressions will be written                                 | `${project.build.directory}/dependency-track/suppressions.json `              |
+| Parameter                    | Description                                                                         | Default Value                                                                 |
+|------------------------------|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `projectName`                | The unique name of the porject in Dependency-Track                                  | `${project.groupId}.${project.artifactId}`                                    |
+| `projectVersion`             | The version of the project in Dependency-Track                                      | `${project.version}`                                                          |
+| `artifactDir`                | The directory of the artifact to upload                                             | `${project.build.directory}`                                                  |
+| `artifactName`               | The name of the artifact to upload                                                  | `bom.xml`                                                                     |
+| `pollToken`                  | Whether to poll the pending token for processing or not                             | `true`                                                                        |
+| `tokenFile`                  | The file path into which the token will be written                                  | `${project.build.directory}/dependency-track/pendingToken`                    |
+| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.                                         | `60` seconds                                                                  |
+| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                                 | `5` seconds                                                                   |
+| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                                | `3` times <br/>                                                               |
+| `securityGate`               | The security gate configuration                                                     | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
+| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                                      | `false`                                                                       |
+| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                                | `true`                                                                        |
+| `cleanupSuppressions`        | Whether to generate a cleaned up suppressions file without unnecessary suppressions | `true`                                                                        |
+| `cleanupSuppressionsFile`    | The file path into which the suppressions will be written                           | `${project.build.directory}/dependency-track/suppressions.json `              |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin is modelled after the [Dependency-Track Jenkins Plugin](https://gith
 Minimum supported Dependency Track version: `3.6.0`
 
 
-- [Quick Overview](#quickoverview)
+- [Quick Overview](#quick-overview)
 - [Usage](#usage)
 - [Configuration](#configuration)
 
@@ -181,24 +181,26 @@ This goal polls Dependency-Track for `tokenPollingDuration`, which defaults to `
 ```
 
 - If a matching suppression found for a finding returned from server and `uploadMatchingSuppressions` is set to `true`, it will be suppressed in Dependency-Track server too by using the provided information.
-- If a matching suppression found for a finding returned from server and `resetExpiredSuppressions` is set to `true`, then the corresponding Analysis is reset in Dependency-Track server, whn the local suppression expires.
+- If a matching suppression found for a finding returned from server and `resetExpiredSuppressions` is set to `true`, then the corresponding Analysis is reset in Dependency-Track server, when the local suppression expires.
 
 Configuration:
 
-| Parameter                    | Description                                             | Default Value                                                                 |
-|------------------------------|---------------------------------------------------------|-------------------------------------------------------------------------------|
-| `projectName`                | The unique name of the porject in Dependency-Track      | `${project.groupId}.${project.artifactId}`                                    |
-| `projectVersion`             | The version of the project in Dependency-Track          | `${project.version}`                                                          |
-| `artifactDir`                | The directory of the artifact to upload                 | `${project.build.directory}`                                                  |
-| `artifactName`               | The name of the artifact to upload                      | `bom.xml`                                                                     |
-| `pollToken`                  | Whether to poll the pending token for processing or not | `true`                                                                        |
-| `tokenFile`                  | The file path into which the token will be written      | `${project.build.directory}/dependency-track/pendingToken`                    |
-| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.             | `60` seconds                                                                  |
-| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics     | `5` seconds                                                                   |
-| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics    | `3` times                                                                     |
-| `securityGate`               | The security gate configuration                         | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
-| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	         | `false`                                                                       |
-| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not    | `true`                                                                        |
+| Parameter                    | Description                                                            | Default Value                                                                 |
+|------------------------------|------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `projectName`                | The unique name of the porject in Dependency-Track                     | `${project.groupId}.${project.artifactId}`                                    |
+| `projectVersion`             | The version of the project in Dependency-Track                         | `${project.version}`                                                          |
+| `artifactDir`                | The directory of the artifact to upload                                | `${project.build.directory}`                                                  |
+| `artifactName`               | The name of the artifact to upload                                     | `bom.xml`                                                                     |
+| `pollToken`                  | Whether to poll the pending token for processing or not                | `true`                                                                        |
+| `tokenFile`                  | The file path into which the token will be written                     | `${project.build.directory}/dependency-track/pendingToken`                    |
+| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.                            | `60` seconds                                                                  |
+| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                    | `5` seconds                                                                   |
+| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                   | `3` times <br/>                                                               |
+| `securityGate`               | The security gate configuration                                        | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
+| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                         | `false`                                                                       |
+| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                   | `true`                                                                        |
+| `generateSuppressions`       | Whether to generate suppressions file without unnecessary suppressions | `true`                                                                        |
+| `generateSuppressionsFile`   | The file path into which the suppressions will be written              | `${project.build.directory}/dependency-track/suppressions.json `              |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -185,22 +185,22 @@ This goal polls Dependency-Track for `tokenPollingDuration`, which defaults to `
 
 Configuration:
 
-| Parameter                    | Description                                                            | Default Value                                                                 |
-|------------------------------|------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| `projectName`                | The unique name of the porject in Dependency-Track                     | `${project.groupId}.${project.artifactId}`                                    |
-| `projectVersion`             | The version of the project in Dependency-Track                         | `${project.version}`                                                          |
-| `artifactDir`                | The directory of the artifact to upload                                | `${project.build.directory}`                                                  |
-| `artifactName`               | The name of the artifact to upload                                     | `bom.xml`                                                                     |
-| `pollToken`                  | Whether to poll the pending token for processing or not                | `true`                                                                        |
-| `tokenFile`                  | The file path into which the token will be written                     | `${project.build.directory}/dependency-track/pendingToken`                    |
-| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.                            | `60` seconds                                                                  |
-| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                    | `5` seconds                                                                   |
-| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                   | `3` times <br/>                                                               |
-| `securityGate`               | The security gate configuration                                        | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
-| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                         | `false`                                                                       |
-| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                   | `true`                                                                        |
-| `generateSuppressions`       | Whether to generate suppressions file without unnecessary suppressions | `true`                                                                        |
-| `generateSuppressionsFile`   | The file path into which the suppressions will be written              | `${project.build.directory}/dependency-track/suppressions.json `              |
+| Parameter                    | Description                                                                               | Default Value                                                                 |
+|------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `projectName`                | The unique name of the porject in Dependency-Track                                        | `${project.groupId}.${project.artifactId}`                                    |
+| `projectVersion`             | The version of the project in Dependency-Track                                            | `${project.version}`                                                          |
+| `artifactDir`                | The directory of the artifact to upload                                                   | `${project.build.directory}`                                                  |
+| `artifactName`               | The name of the artifact to upload                                                        | `bom.xml`                                                                     |
+| `pollToken`                  | Whether to poll the pending token for processing or not                                   | `true`                                                                        |
+| `tokenFile`                  | The file path into which the token will be written                                        | `${project.build.directory}/dependency-track/pendingToken`                    |
+| `tokenPollingDuration`       | Polling timeout for the uploaded BOM token.                                               | `60` seconds                                                                  |
+| `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                                       | `5` seconds                                                                   |
+| `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                                      | `3` times <br/>                                                               |
+| `securityGate`               | The security gate configuration                                                           | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
+| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                                            | `false`                                                                       |
+| `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                                      | `true`                                                                        |
+| `cleanupSuppressions`        | Whether to generate a cleaned up suppressions file without unnecessary suppressions <br/> | `true`     <br/> <br/> <br/> <br/> <br/> <br/> <br/>                          |
+| `cleanupSuppressionsFile`    | The file path into which the suppressions will be written                                 | `${project.build.directory}/dependency-track/suppressions.json `              |
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.iabudiab</groupId>
 	<artifactId>dependency-track-maven-plugin</artifactId>
-	<version>2.3.1</version>
+	<version>2.4.0</version>
 	<packaging>maven-plugin</packaging>
 	<name>Dependency Track Maven Plugin</name>
 	<description>Maven plugin for interacting with Dependency Track</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.iabudiab</groupId>
 	<artifactId>dependency-track-maven-plugin</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<packaging>maven-plugin</packaging>
 	<name>Dependency Track Maven Plugin</name>
 	<description>Maven plugin for interacting with Dependency Track</description>

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/SecurityGate.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/SecurityGate.java
@@ -156,7 +156,7 @@ public class SecurityGate {
 			}
 		}
 
-		public void generateEffectiveSuppressionsFile(Log log, String suppressionsFile) throws MojoExecutionException {
+		public void cleanupSuppressionsFile(Log log, String suppressionsFile) throws MojoExecutionException {
 			try {
 				Path targetSuppressionsFilePath = Paths.get(suppressionsFile);
 				Files.createDirectories(targetSuppressionsFilePath.getParent());

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/SecurityGate.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/SecurityGate.java
@@ -56,6 +56,8 @@ public class SecurityGate {
 		reportBuilder.append("\n");
 
 		List<Finding> effectiveFindings = new ArrayList<>();
+		List<Suppression> remainingSuppression = new ArrayList<>(suppressions.getSuppressions());
+
 
 		for (Finding finding : findings) {
 			if (finding.getAnalysis().isSuppressed()) {
@@ -76,6 +78,7 @@ public class SecurityGate {
 				continue;
 			}
 
+			remainingSuppression.remove(suppression);
 			if (suppression.isExpired()) {
 				reportBuilder.append("- Active finding with expired custom suppression for: [").append(finding.getComponent().getPurl()).append("]");
 				effectiveFindings.add(finding);
@@ -94,6 +97,10 @@ public class SecurityGate {
 				: suppression.getExpiration().toString();
 			reportBuilder.append(" [suppression expiration date: ").append(expiration).append("]");
 			reportBuilder.append("\n");
+		}
+
+		for (Suppression suppression: remainingSuppression) {
+			reportBuilder.append("- Unnecessary suppression for: ").append(suppression.printIdentifier()).append("\n");
 		}
 
 		return new SecurityReport(true, reportBuilder.toString(), effectiveFindings);

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
@@ -98,6 +98,19 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 	@Parameter(property = "resetExpiredSuppressions", defaultValue = "true", required = false)
 	protected boolean resetExpiredSuppressions;
 
+	/**
+	 * Whether suppressions file should be created from effective suppressions.
+	 */
+	@Parameter(property = "generateSuppressions", defaultValue = "true", required = false)
+	protected boolean generateSuppressions;
+
+	/**
+	 * Suppressions file path containing effective suppressions.
+	 */
+	@Parameter(defaultValue = "${project.build.directory}/dependency-track/suppressions.json", property = "generateSuppressionsFile", required = false)
+	private String generateSuppressionsFile;
+
+
 	@Override
 	protected void logGoalConfiguration() {
 		getLog().info("Using artifact directory        : " + artifactDirectory);
@@ -193,6 +206,9 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
 		SecurityGate.SecurityReport securityReport = securityGate.applyOn(findings, suppressions);
 		securityReport.execute(getLog());
+		if (generateSuppressions) {
+			securityReport.generateEffectiveSuppressionsFile(getLog(), generateSuppressionsFile);
+		}
 	}
 
 	private void uploadSuppressions(DTrackClient client, Suppressions suppressions, Project project, List<Finding> findings) throws MojoExecutionException {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
@@ -101,14 +101,14 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 	/**
 	 * Whether suppressions file should be created from effective suppressions.
 	 */
-	@Parameter(property = "generateSuppressions", defaultValue = "true", required = false)
-	protected boolean generateSuppressions;
+	@Parameter(property = "cleanupSuppressions", defaultValue = "true", required = false)
+	protected boolean cleanupSuppressions;
 
 	/**
 	 * Suppressions file path containing effective suppressions.
 	 */
-	@Parameter(defaultValue = "${project.build.directory}/dependency-track/suppressions.json", property = "generateSuppressionsFile", required = false)
-	private String generateSuppressionsFile;
+	@Parameter(defaultValue = "${project.build.directory}/dependency-track/suppressions.json", property = "cleanupSuppressionsFile", required = false)
+	private String cleanupSuppressionsFile;
 
 
 	@Override
@@ -206,8 +206,8 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
 		SecurityGate.SecurityReport securityReport = securityGate.applyOn(findings, suppressions);
 		securityReport.execute(getLog());
-		if (generateSuppressions) {
-			securityReport.generateEffectiveSuppressionsFile(getLog(), generateSuppressionsFile);
+		if (cleanupSuppressions) {
+			securityReport.cleanupSuppressionsFile(getLog(), cleanupSuppressionsFile);
 		}
 	}
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
@@ -25,7 +25,7 @@ public class SuppressByPurl implements Suppression {
 	private LocalDate expiration = LocalDate.MAX;
 	private String purl;
 
-	private final boolean regex = false;
+	private boolean regex = false;
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
@@ -52,4 +52,9 @@ public class SuppressByPurl implements Suppression {
 		builder.append(" [expired: ").append(isExpired() ? "yes": "no").append("]");
 		return builder.toString();
 	}
+
+	@Override
+	public CharSequence printIdentifier() {
+		return "[" + purl + "]";
+	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
@@ -10,50 +10,22 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
+import lombok.Data;
 
+@Data
 @JsonTypeName("purl")
 public class SuppressByPurl implements Suppression {
 
-	private final String type = "purl";
+	private String type = "purl";
 
 	private String notes;
-	private final State state = State.NOT_SET;
-	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private final LocalDate expiration = LocalDate.MAX;
+	private State state = State.NOT_SET;
+	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private LocalDate expiration = LocalDate.MAX;
 	private String purl;
 
 	private final boolean regex = false;
-
-	@Override
-	public String getType() {
-		return type;
-	}
-
-	@Override
-	public String getNotes() {
-		return notes;
-	}
-
-	@Override
-	public State getState() {
-		return state;
-	}
-
-	@Override
-	public AnalysisJustification getJustification() {
-		return justification;
-	}
-
-	@Override
-	public AnalysisResponse getResponse() {
-		return response;
-	}
-
-	@Override
-	public LocalDate getExpiration() {
-		return expiration;
-	}
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {
@@ -77,7 +49,7 @@ public class SuppressByPurl implements Suppression {
 		}
 
 		builder.append("[").append(purl).append("]");
-		builder.append(" [expired: ").append(isExpired() ? "yes": "no").append("]");
+		builder.append(" [expired: ").append(isExpired() ? "yes" : "no").append("]");
 		return builder.toString();
 	}
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressByPurl.java
@@ -10,22 +10,50 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
-import lombok.Data;
 
-@Data
 @JsonTypeName("purl")
 public class SuppressByPurl implements Suppression {
 
-	private String type = "purl";
+	private final String type = "purl";
 
 	private String notes;
-	private State state = State.NOT_SET;
-	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private LocalDate expiration = LocalDate.MAX;
+	private final State state = State.NOT_SET;
+	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private final LocalDate expiration = LocalDate.MAX;
 	private String purl;
 
-	private boolean regex = false;
+	private final boolean regex = false;
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public String getNotes() {
+		return notes;
+	}
+
+	@Override
+	public State getState() {
+		return state;
+	}
+
+	@Override
+	public AnalysisJustification getJustification() {
+		return justification;
+	}
+
+	@Override
+	public AnalysisResponse getResponse() {
+		return response;
+	}
+
+	@Override
+	public LocalDate getExpiration() {
+		return expiration;
+	}
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
@@ -8,48 +8,20 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
+import lombok.Data;
 
+@Data
 @JsonTypeName("cve")
 public class SuppressCve implements Suppression {
 
-	private final String type = "cve";
+	private String type = "cve";
 
 	private String notes;
-	private final State state = State.NOT_SET;
-	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private final LocalDate expiration = LocalDate.MAX;
+	private State state = State.NOT_SET;
+	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private LocalDate expiration = LocalDate.MAX;
 	private String cve;
-
-	@Override
-	public String getType() {
-		return type;
-	}
-
-	@Override
-	public String getNotes() {
-		return notes;
-	}
-
-	@Override
-	public State getState() {
-		return state;
-	}
-
-	@Override
-	public AnalysisJustification getJustification() {
-		return justification;
-	}
-
-	@Override
-	public AnalysisResponse getResponse() {
-		return response;
-	}
-
-	@Override
-	public LocalDate getExpiration() {
-		return expiration;
-	}
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
@@ -36,4 +36,9 @@ public class SuppressCve implements Suppression {
 		builder.append(" [expired: ").append(isExpired() ? "yes": "no").append("]");
 		return builder.toString();
 	}
+
+	@Override
+	public CharSequence printIdentifier() {
+		return "[" + cve + "]";
+	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCve.java
@@ -8,20 +8,48 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
-import lombok.Data;
 
-@Data
 @JsonTypeName("cve")
 public class SuppressCve implements Suppression {
 
-	private String type = "cve";
+	private final String type = "cve";
 
 	private String notes;
-	private State state = State.NOT_SET;
-	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private LocalDate expiration = LocalDate.MAX;
+	private final State state = State.NOT_SET;
+	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private final LocalDate expiration = LocalDate.MAX;
 	private String cve;
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public String getNotes() {
+		return notes;
+	}
+
+	@Override
+	public State getState() {
+		return state;
+	}
+
+	@Override
+	public AnalysisJustification getJustification() {
+		return justification;
+	}
+
+	@Override
+	public AnalysisResponse getResponse() {
+		return response;
+	}
+
+	@Override
+	public LocalDate getExpiration() {
+		return expiration;
+	}
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
@@ -10,23 +10,51 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
-import lombok.Data;
 
-@Data
 @JsonTypeName("cve-of-purl")
 public class SuppressCveOfPurl implements Suppression {
 
-	private String type = "cve-of-purl";
+	private final String type = "cve-of-purl";
 
 	private String notes;
-	private State state = State.NOT_SET;
-	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private LocalDate expiration = LocalDate.MAX;
+	private final State state = State.NOT_SET;
+	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private final LocalDate expiration = LocalDate.MAX;
 	private String purl;
 	private String cve;
 
-	private boolean regex = false;
+	private final boolean regex = false;
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public String getNotes() {
+		return notes;
+	}
+
+	@Override
+	public State getState() {
+		return state;
+	}
+
+	@Override
+	public AnalysisJustification getJustification() {
+		return justification;
+	}
+
+	@Override
+	public AnalysisResponse getResponse() {
+		return response;
+	}
+
+	@Override
+	public LocalDate getExpiration() {
+		return expiration;
+	}
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
@@ -10,51 +10,23 @@ import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
+import lombok.Data;
 
+@Data
 @JsonTypeName("cve-of-purl")
 public class SuppressCveOfPurl implements Suppression {
 
-	private final String type = "cve-of-purl";
+	private String type = "cve-of-purl";
 
 	private String notes;
-	private final State state = State.NOT_SET;
-	private final AnalysisJustification justification = AnalysisJustification.NOT_SET;
-	private final AnalysisResponse response = AnalysisResponse.NOT_SET;
-	private final LocalDate expiration = LocalDate.MAX;
+	private State state = State.NOT_SET;
+	private AnalysisJustification justification = AnalysisJustification.NOT_SET;
+	private AnalysisResponse response = AnalysisResponse.NOT_SET;
+	private LocalDate expiration = LocalDate.MAX;
 	private String purl;
 	private String cve;
 
-	private final boolean regex = false;
-
-	@Override
-	public String getType() {
-		return type;
-	}
-
-	@Override
-	public String getNotes() {
-		return notes;
-	}
-
-	@Override
-	public State getState() {
-		return state;
-	}
-
-	@Override
-	public AnalysisJustification getJustification() {
-		return justification;
-	}
-
-	@Override
-	public AnalysisResponse getResponse() {
-		return response;
-	}
-
-	@Override
-	public LocalDate getExpiration() {
-		return expiration;
-	}
+	private boolean regex = false;
 
 	@Override
 	public boolean suppressesFinding(Finding finding) {

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/SuppressCveOfPurl.java
@@ -60,4 +60,9 @@ public class SuppressCveOfPurl implements Suppression {
 		builder.append(" [Expired: ").append(isExpired() ? "yes": "no").append("]");
 		return builder.toString();
 	}
+
+	@Override
+	public CharSequence printIdentifier() {
+		return "[" + purl + "] [" + cve + "]";
+	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
@@ -20,7 +20,7 @@ import iabudiab.maven.plugins.dependencytrack.client.model.State;
 public interface Suppression {
 
 	@JsonProperty("by")
-	String type = null;
+	String getType();
 
 	String getNotes();
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
@@ -48,4 +48,6 @@ public interface Suppression {
 	}
 
 	CharSequence print();
+
+	CharSequence printIdentifier();
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
@@ -20,7 +20,7 @@ import iabudiab.maven.plugins.dependencytrack.client.model.State;
 public interface Suppression {
 
 	@JsonProperty("by")
-	String getType();
+	String type = null;
 
 	String getNotes();
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/suppressions/Suppression.java
@@ -11,7 +11,7 @@ import iabudiab.maven.plugins.dependencytrack.client.model.State;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "by", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "by", include = JsonTypeInfo.As.EXISTING_PROPERTY, visible = true)
 @JsonSubTypes({
 	@JsonSubTypes.Type(value = SuppressByPurl.class, name = "purl"),
 	@JsonSubTypes.Type(value = SuppressCve.class, name = "cve"),


### PR DESCRIPTION
Unnecessary suppressions are printed in the report to make it easier to clean up the suppressions file.
Additionally configuration is added to generate a new suppression file containing only the effective suppressions.
The properties are:
- cleanupSuppressions (default=true, defines whether the suppressions file should be generated)
- cleanupSuppressionsFile (default="${project.build.directory}/dependency-track/suppressions.json", defines the path of the generated file)