### PR TITLE
added support for hierarchical project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Configuration:
 
 | Parameter                 | Description                                                | Default Value                               |
 |---------------------------|------------------------------------------------------------|---------------------------------------------|
-| `projectName`             | The unique name of the porject in Dependency-Track         | `${project.groupId}.${project.artifactId}`  |
+| `projectName`             | The unique name of the project in Dependency-Track         | `${project.groupId}.${project.artifactId}`  |
 | `projectVersion`          | The version of the project in Dependency-Track             | `${project.version}`                        |
 | `artifactDir`             | The directory of the artifact to upload                    | `${project.build.directory}`                |
 | `artifactName`            | The name of the artifact to upload                         | `dependency-check-report.xml`               |
@@ -189,7 +189,7 @@ Configuration:
 
 | Parameter                    | Description                                                                         | Default Value                                                                 |
 |------------------------------|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| `projectName`                | The unique name of the porject in Dependency-Track                                  | `${project.groupId}.${project.artifactId}`                                    |
+| `projectName`                | The unique name of the project in Dependency-Track                                  | `${project.groupId}.${project.artifactId}`                                    |
 | `projectVersion`             | The version of the project in Dependency-Track                                      | `${project.version}`                                                          |
 | `artifactDir`                | The directory of the artifact to upload                                             | `${project.build.directory}`                                                  |
 | `artifactName`               | The name of the artifact to upload                                                  | `bom.xml`                                                                     |
@@ -217,7 +217,7 @@ Configuration:
 
 | Parameter          | Description                                                                   | Default Value                                                   |
 |--------------------|-------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| `projectName`      | The unique name of the porject in Dependency-Track                            | `${project.groupId}.${project.artifactId}`                      |
+| `projectName`      | The unique name of the project in Dependency-Track                            | `${project.groupId}.${project.artifactId}`                      |
 | `projectVersion`   | The version of the project in Dependency-Track                                | `${project.version}`                                            |
 | `destinationPath`  | The destination directory where the BOM will be downloaded                    | `${project.build.directory}/${project.build.finalName}_bom.xml` |
 | `outputFormat`     | The format of the BOM to download from Dependency-Track (**XML** or **JSON**) | XML                                                             |
@@ -235,7 +235,7 @@ Configuration:
 
 | Parameter                 | Description                                                | Default Value                                                                   |
 |---------------------------|------------------------------------------------------------|---------------------------------------------------------------------------------|
-| `projectName`             | The unique name of the porject in Dependency-Track         | `${project.groupId}.${project.artifactId}`                                      |
+| `projectName`             | The unique name of the project in Dependency-Track         | `${project.groupId}.${project.artifactId}`                                      |
 | `projectVersion`          | The version of the project in Dependency-Track             | `${project.version}`                                                            |
 | `tokenFile`               | The file path into which the token will be written         | `${project.build.directory}/dependency-track/pendingToken`                      |
 | `tokenValue`              | The UUID value of the pending token                        |                                                                                 |
@@ -252,7 +252,7 @@ Configuration:
 
 | Parameter                 | Description                                                | Default Value                                                                   |
 |---------------------------|------------------------------------------------------------|---------------------------------------------------------------------------------|
-| `projectName`             | The unique name of the porject in Dependency-Track         | `${project.groupId}.${project.artifactId}`                                      |
+| `projectName`             | The unique name of the project in Dependency-Track         | `${project.groupId}.${project.artifactId}`                                      |
 | `projectVersion`          | The version of the project in Dependency-Track             | `${project.version}`                                                            |
 | `securityGate`            | The security gate configuration                            | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul>   |
 
@@ -308,7 +308,7 @@ Here are all the main configuration parameters summarized:
 | `skip`                       | Skip plugin execution for the current project            | `false`                                                                                                  |
 | `failOnError`                | Whether errors should fail the build                     | `true`                                                                                                   |
 | `logPayloads`                | Whether the plugin should log request/response payloads  | `false`                                                                                                  |
-| `projectName`                | The unique name of the porject in Dependency-Track       | `${project.groupId}.${project.artifactId}`                                                               |
+| `projectName`                | The unique name of the project in Dependency-Track       | `${project.groupId}.${project.artifactId}`                                                               |
 | `projectVersion`             | The version of the project in Dependency-Track           | `${project.version}`                                                                                     |
 | `artifactDir`                | The directory of the artifact to upload                  | `${project.build.directory}`                                                                             |
 | `artifactName`               | The name of the artifact to upload                       | <ul><li>`upload-scan` goal: `dependency-check-report.xml`</li><li>`upload-bom` goal: `bom.xml`</li></ul> |

--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ Configuration:
 
 Uploads a CycloneDX or SPDX BOM to Dependency-Track. A project is created in Dependency-Track if it doesn't already exist.
 
+If both, `parentName` and `parentVersion` are specified (not empty), the appropriate parent project will be applied as a parent to the target project. If `autoCreateParent` is set to `true` and no matching parent project found in Dependency-Track, an appropriate parent project will be created first, otherwise the assigned parent project will be left as is. 
+
 Upon uploading a BOM to Dependency-Track a token is returned, which can be checked for processing status if `pollToken` is `true`.
 
-If `pollToken` is set to `false`, then this goal would upload the BOM, write the token to a file at `tokenFile` and then exit.
+If `pollToken` is set to `false`, then this goal would upload the BOM, optionally assign the specified parent project, write the token to a file at `tokenFile` and then exit.
 
 Once the token is processed, the findings are available and can be fetched for further analysis.
 
@@ -197,10 +199,13 @@ Configuration:
 | `projectMetricsRetryDelay`   | Delay between each retry requesting project metrics                                 | `5` seconds                                                                   |
 | `projectMetricsRetryLimit`   | Maximum number of retries requesting project metrics                                | `3` times <br/>                                                               |
 | `securityGate`               | The security gate configuration                                                     | <ul><li>critial: 0</li><li>high: 0</li><li>medium: 0</li><li>low: 0</li></ul> |
-| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                                      | `false`                                                                       |
+| `uploadMatchingSuppressions` | Whether to upload matching suppression or not	                                     | `false`                                                                       |
 | `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                                | `true`                                                                        |
 | `cleanupSuppressions`        | Whether to generate a cleaned up suppressions file without unnecessary suppressions | `true`                                                                        |
 | `cleanupSuppressionsFile`    | The file path into which the suppressions will be written                           | `${project.build.directory}/dependency-track/suppressions.json `              |
+| `parentName`                 | The unique name of the parent project in Dependency-Track                           | empty                                                                         |
+| `parentVersion`              | The version of the parent project in Dependency-Track                               | empty                                                                         |
+| `autoCreateParent`           | Whether to create or not the specified parent project if no such project exists     | `false`                                                                       |
 
 ---
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/DiffWithDependencyTrackBomMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/DiffWithDependencyTrackBomMojo.java
@@ -1,22 +1,24 @@
 package iabudiab.maven.plugins.dependencytrack;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
-import iabudiab.maven.plugins.dependencytrack.client.DTrackClient;
-import iabudiab.maven.plugins.dependencytrack.client.model.Project;
-import iabudiab.maven.plugins.dependencytrack.cyclone.*;
-import iabudiab.maven.plugins.dependencytrack.dtrack.DTrack;
-import iabudiab.maven.plugins.dependencytrack.dtrack.DTrackException;
-import iabudiab.maven.plugins.dependencytrack.dtrack.DTrackNotFoundException;
-import org.apache.http.client.HttpResponseException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cyclonedx.model.Bom;
+
+import iabudiab.maven.plugins.dependencytrack.cyclone.BomFormat;
+import iabudiab.maven.plugins.dependencytrack.cyclone.BomUtils;
+import iabudiab.maven.plugins.dependencytrack.cyclone.DiffResult;
+import iabudiab.maven.plugins.dependencytrack.cyclone.DiffResultsWriter;
+import iabudiab.maven.plugins.dependencytrack.cyclone.DiffUtils;
+import iabudiab.maven.plugins.dependencytrack.cyclone.OutputFormat;
+import iabudiab.maven.plugins.dependencytrack.dtrack.DTrack;
+import iabudiab.maven.plugins.dependencytrack.dtrack.DTrackException;
+import iabudiab.maven.plugins.dependencytrack.dtrack.DTrackNotFoundException;
 
 /**
  * Mojo for building a Diff between a local BOM and the corresponding BOM in Dependency Track.

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/BomSubmitRequest.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/BomSubmitRequest.java
@@ -13,6 +13,10 @@ public class BomSubmitRequest {
 
 	private String projectVersion;
 
+	private String parentName;
+
+	private String parentVersion;
+
 	private Boolean autoCreate;
 
 	private String bom;

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
@@ -13,4 +13,5 @@ public class Project {
 	private UUID uuid;
 	private String name;
 	private String version;
+	private Project parent;
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/TokenResponse.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/TokenResponse.java
@@ -1,16 +1,10 @@
 package iabudiab.maven.plugins.dependencytrack.client.model;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
-import org.apache.maven.plugin.MojoExecutionException;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/FindingsReport.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/FindingsReport.java
@@ -1,7 +1,6 @@
 package iabudiab.maven.plugins.dependencytrack.dtrack;
 
 import java.util.List;
-import java.util.Optional;
 
 import iabudiab.maven.plugins.dependencytrack.client.model.Analysis;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;


### PR DESCRIPTION
Added support for hierachical project structure, introduced in dependency-track 4.7.0.

When uploading a bom and a parent project is specified (`parentName` and `parentVersion`), now trying to find the appropriate project in Dependency-Track. If the bom-targeting project already has the desired parent project assigned, nothing will change. Otherwise, the matching parent project will be applied to the bom-targeting project. If no matching parent project found in Dependency-Track, whether create it or not, according to the new setting `autoCreateParent`.

Additionally, removed unused imports to get rid of some warnings and fixed some typos in readme.