### PR TITLE
support for new collection projects feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Configuration:
 | `resetExpiredSuppressions`   | Whether to reset matching expired suppression or not                                | `true`                                                                        |
 | `cleanupSuppressions`        | Whether to generate a cleaned up suppressions file without unnecessary suppressions | `true`                                                                        |
 | `cleanupSuppressionsFile`    | The file path into which the suppressions will be written                           | `${project.build.directory}/dependency-track/suppressions.json `              |
+| `parentIdentifier`           | The unique identifier (UUID) of the parent project in Dependency-Track              | empty                                                                         |
 | `parentName`                 | The unique name of the parent project in Dependency-Track                           | empty                                                                         |
 | `parentVersion`              | The version of the parent project in Dependency-Track                               | empty                                                                         |
 | `autoCreateParent`           | Whether to create or not the specified parent project if no such project exists     | `false`                                                                       |

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Configuration:
 | `parentName`                 | The unique name of the parent project in Dependency-Track                           | empty                                                                         |
 | `parentVersion`              | The version of the parent project in Dependency-Track                               | empty                                                                         |
 | `autoCreateParent`           | Whether to create or not the specified parent project if no such project exists     | `false`                                                                       |
+| `parentCollectionLogic`      | The collection logic that should be applied to the created parent project           | empty                                                                         |
+| `parentCollectionTag`        | The collection tag that should be applied to the created parent project             | empty                                                                         |
+| `collectionLogic`            | The collection logic that should be applied to the current project                  | empty                                                                         |
+| `collectionTag`              | The collection tag that should be applied to the current project                    | empty                                                                         |
 
 ---
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
@@ -16,9 +16,11 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import iabudiab.maven.plugins.dependencytrack.client.model.CollectionLogic;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.Project;
 import iabudiab.maven.plugins.dependencytrack.client.model.ProjectMetrics;
+import iabudiab.maven.plugins.dependencytrack.client.model.Tag;
 import iabudiab.maven.plugins.dependencytrack.client.model.TokenResponse;
 import iabudiab.maven.plugins.dependencytrack.dtrack.DTrack;
 import iabudiab.maven.plugins.dependencytrack.dtrack.DTrackException;
@@ -139,6 +141,30 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 	@Parameter(property = "autCreateParent", defaultValue = "false", required = false)
 	private boolean autoCreateParent;
 
+	/**
+	 * The collection logic that should be applied to this project's autocreated parent in Dependency-Track, thus only takes effect when 'autoCreateParent' is set to 'true' and no such parent found
+	 */
+	@Parameter(property = "parentCollectionLogic", defaultValue = "", required = false)
+	protected String parentCollectionLogic;
+
+	/**
+	 * The collection logic that should be applied to this project's autocreated parent in Dependency-Track, thus only takes effect when 'autoCreateParent' is set to 'true' and no such parent found
+	 */
+	@Parameter(property = "parentCollectionTag", defaultValue = "", required = false)
+	protected String parentCollectionTag;
+
+	/**
+	 * The collection logic that should be applied to this project in Dependency-Track
+	 */
+	@Parameter(property = "collectionLogic", defaultValue = "", required = false)
+	protected String collectionLogic;
+
+	/**
+	 * The collection tag that should be applied to the project in Dependency-Track
+	 */
+	@Parameter(property = "collectionTag", defaultValue = "", required = false)
+	protected String collectionTag;
+
 
 	@Override
 	protected void logGoalConfiguration() {
@@ -152,19 +178,58 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 		getLog().info("Parent name                     : " + parentName);
 		getLog().info("Parent version                  : " + parentVersion);
 		getLog().info("Auto create parent              : " + autoCreateParent);
-
+		getLog().info("Parent's Collection logic       : " + parentCollectionLogic);
+		getLog().info("Parent's Collection tag         : " + parentCollectionTag);
+		getLog().info("Collection logic                : " + collectionLogic);
+		getLog().info("Collection tag                  : " + collectionTag);
 	}
 
 	@Override
 	protected void doWork(DTrack dtrack) throws DTrackException, MojoExecutionException {
 		Path path = Paths.get(artifactDirectory.getPath(), artifactName);
+		getLog().debug("start uploading bom ...");
 
-		TokenResponse tokenResponse = dtrack.uploadBom(path);
+		// even if the bom upload failed, we want to continue
+		TokenResponse tokenResponse = null;
+		try {
+			tokenResponse = dtrack.uploadBom(path);
+		} catch(DTrackException ex) {
+			getLog().warn("got exception when uploading bom!", ex);
+		}
 
-		if ( !ObjectUtils.isEmpty(parentIdentifier) || (!ObjectUtils.isEmpty(parentName) && !ObjectUtils.isEmpty(parentVersion)) ) {
-			applyParent(dtrack);
+		// try to apply parent to current project in dependency track
+		if ( !ObjectUtils.isEmpty(parentIdentifier) || (!ObjectUtils.isEmpty(parentName)) ) {
+			try {
+				getLog().debug(
+							parentIdentifier != null 
+							? String.format("try to apply parent by identifier '%s'", parentIdentifier)
+							: String.format("try to apply parent '%s:%s'", parentName, parentVersion));
+				applyParent(dtrack);
+				getLog().info(
+							parentIdentifier != null 
+							? String.format("successfully applied parent by identifier '%s'", parentIdentifier)
+							: String.format("successfully applied parent '%s:%s'", parentName, parentVersion));
+			} catch(Exception ex) {
+				getLog().warn(String.format("something went wrong applying parent!"), ex);
+			}
 		} else {
 			getLog().debug("No parent specified");
+		}
+
+		// try to apply collection logic to current project in dependency track
+		if( !ObjectUtils.isEmpty(collectionLogic) ) {
+			try {
+				getLog().debug(String.format("try to apply collection logic '%s'", collectionLogic));
+				applyCollectionLogic(dtrack);
+				getLog().info(String.format("successfully applied collection logic '%s'", collectionLogic));
+			} catch(Exception ex) {}
+		} else {
+			getLog().debug("No collection logic specified");
+		}
+
+		// when the bom upload failed, we want to stop execution here, since the further steps require a valid token response
+		if(tokenResponse == null) {
+			return;
 		}
 
 		try {
@@ -186,7 +251,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 			getLog().info("Timeout while waiting for BOM token, bailing out.");
 			return;
 		}
-
+		
 		List<Finding> findings = dtrack.loadFindings();
 		FindingsReport findingsReport = new FindingsReport(findings);
 		getLog().info(InfoPrinter.print(findingsReport));
@@ -213,6 +278,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 	}
 
 	private void applyParent(DTrack dtrack) {
+		getLog().debug(String.format("try to obtain current project"));
 		Project project = dtrack.findProject(projectName, projectVersion);
 
 		UUID parentUuid = null;
@@ -235,12 +301,14 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 		}
 
 		// try to obtain the parent project
+		getLog().debug(String.format("try to obtain parent project either by identifier '%s' or by name and version '%s:%s'", parentUuid, parentName, parentVersion));
 		parentProject = parentUuid != null
 						? dtrack.findProject(parentUuid)
 						: dtrack.findProject(parentName, parentVersion);
 
 		// autocreate should only be applied when parent project is specified by 'projectName' and 'projectVersion' and not by parent uuid
-		if (parentProject == null && parentUuid == null) {
+		if (parentProject == null && parentUuid == null && autoCreateParent) {
+			// for debugging purposes we split the conditional statement into two
 			if (autoCreateParent) {
 				// if no such parent project found, create it
 				getLog().info(String.format(
@@ -248,7 +316,18 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 					parentName, parentVersion
 				));
 
-				parentProject = dtrack.createProject(parentName, parentVersion);
+				// parsing parent's collectionLogic
+				CollectionLogic logic = null;
+				try {
+					logic = CollectionLogic.valueOf(parentCollectionLogic);
+				} catch(Exception ex) {
+					getLog().warn(String.format("could not parse value '%s' to a valid collection logic strategy! Continue and handle it as 'null'", collectionLogic), ex);
+				}
+
+				// parsing parent's collectionTag
+				Tag tag = !ObjectUtils.isEmpty(parentCollectionTag) ? new Tag(parentCollectionTag) : null;
+
+				parentProject = dtrack.createProject(parentName, parentVersion, logic, tag);
 
 				getLog().info(String.format("Parent project '%s:%s' successfully created with uuid '%s'",
 					parentName, parentVersion, parentProject.getUuid()
@@ -262,9 +341,29 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 		}
 
 		if (parentProject != null) {
+			getLog().debug(String.format("try to apply parent project"));
 			dtrack.applyParentProject(project, parentProject);
 		} else {
 			getLog().warn("Skip applying parent project");
+		}
+	}
+
+	private void applyCollectionLogic(DTrack dtrack) {
+		CollectionLogic logic = null;
+		try {
+			logic = CollectionLogic.valueOf(collectionLogic);
+		} catch(Exception ex) {
+			getLog().warn(String.format("could not parse value '%s' to a valid collection logic strategy! Skip applying collection logic.", collectionLogic), ex);
+			return;
+		}
+		String tag = (collectionTag == null || collectionTag.isEmpty()) ? null : collectionTag.trim();
+
+		Project project = dtrack.findProject(projectName, projectVersion);
+
+		try {
+			dtrack.applyCollectionLogic(project, logic, tag);
+		} catch (Exception ex) {
+			getLog().warn(String.format("something went wrong applying collection logic '%s' and tag '%s'!", logic, tag), ex);
 		}
 	}
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -29,6 +30,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.EntityBuilder;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -44,10 +46,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import iabudiab.maven.plugins.dependencytrack.client.model.Analysis;
 import iabudiab.maven.plugins.dependencytrack.client.model.BomSubmitRequest;
+import iabudiab.maven.plugins.dependencytrack.client.model.CollectionLogic;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.Project;
 import iabudiab.maven.plugins.dependencytrack.client.model.ProjectMetrics;
 import iabudiab.maven.plugins.dependencytrack.client.model.ScanSubmitRequest;
+import iabudiab.maven.plugins.dependencytrack.client.model.Tag;
 import iabudiab.maven.plugins.dependencytrack.client.model.TokenProcessedResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.TokenResponse;
 import iabudiab.maven.plugins.dependencytrack.cyclone.BomFormat;
@@ -198,33 +202,65 @@ public class DTrackClient {
 		return client.execute(request, responseBodyHandler(Project.class));
 	}
 
-	public Project createProject(String name, String version) throws IOException {
+	public Project createProject(String name, String version, CollectionLogic collectionLogic, Tag collectionTag) throws IOException {
 		URI uri = baseUri.resolve(API_PROJECT);
 		Project payload = new Project();
 		payload.setName(name);
 		payload.setVersion(version);
+		payload.setCollectionLogic(collectionLogic == null ? CollectionLogic.NONE : collectionLogic);
+		payload.setCollectionTag(collectionTag);
 		String payloadAsString = objectMapper.writeValueAsString(payload);
 		HttpPut request = httpPut(uri, payloadAsString);
 		log.info(String.format("Creating project '%s:%s' by: %s", payload.getName(), payload.getVersion(), uri));
 		Project response = client.execute(request, responseBodyHandler(Project.class));
-		log.info("successfully created project uuid: " + response.getUuid());
+		log.info("successfully created project: " + response);
 		return response;
 	}
 
 	public Project applyProjectParent(Project project, Project parent) throws IOException {
+		// since there is a bug in DTrack v4.13.0 that resets the collectionLogic when PATCHing a project, we POSTing it instead
+		project.setParent(parent);
+		return postProject(project);
+	}
+
+	public Project applyCollectionLogic(Project project, CollectionLogic collectionLogic, String collectionTag) throws IOException {
+		if(collectionLogic == null) throw new IllegalArgumentException("collectionLogic should not be 'null'!");
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("collectionLogic", collectionLogic);
+		payload.put("collectionTag", !ObjectUtils.isEmpty(collectionTag) ? new Tag(collectionTag) : null);
+		return patchProject(project, payload);
+	}
+
+	public Project patchProject(Project project, Map<String, Object> payload) throws IOException {
 		URI uri = baseUri.resolve(API_PROJECT + "/" + project.getUuid().toString());
-		Map<String, Object> payload = Collections.singletonMap("parent", Collections.singletonMap("uuid", parent.getUuid().toString()));
 		String payloadAsString = objectMapper.writeValueAsString(payload);
 		HttpPatch request = httpPatch(uri, payloadAsString);
-		log.info(String.format("Patching project '%s:%s' to apply parent '%s:%s' by: %s",
-			project.getName(), project.getVersion(), parent.getName(), parent.getVersion(), uri
+		log.debug(String.format("Patching project '%s:%s' by applying payload: '%s'",
+			project.getName(), project.getVersion(), payloadAsString
 		));
 
 		Project response = client.execute(request, responseBodyHandler(Project.class));
-		log.info(String.format(
-			"Successfully patched project '%s:%s' by applying parent '%s:%s'",
-			project.getName(), project.getVersion(), parent.getName(), parent.getVersion()
+		log.debug(String.format(
+			"Successfully patched project '%s:%s' by applying payload: '%s'",
+			project.getName(), project.getVersion(), payloadAsString
 		));
+		return response;
+	}
+
+	public Project postProject(Project project) throws IOException {
+		URI uri = baseUri.resolve(API_PROJECT);
+		String payloadAsString = objectMapper.writeValueAsString(project);
+		HttpPost request = httpPost(uri, payloadAsString);
+		log.debug(String.format("Posting project: '%s'",
+			payloadAsString
+		));
+
+		Project response = client.execute(request, responseBodyHandler(Project.class));
+		log.debug(String.format(
+			"Successfully posted project: '%s'",
+			objectMapper.writeValueAsString(response)
+		));
+
 		return response;
 	}
 
@@ -334,6 +370,13 @@ public class DTrackClient {
 
 	private HttpPut httpPut(URI uri, String body) {
 		HttpPut request = new HttpPut();
+		request.setURI(uri);
+		request.setEntity(EntityBuilder.create().setText(body).build());
+		return request;
+	}
+
+	private HttpPost httpPost(URI uri, String body) {
+		HttpPost request = new HttpPost();
 		request.setURI(uri);
 		request.setEntity(EntityBuilder.create().setText(body).build());
 		return request;

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
@@ -180,6 +180,12 @@ public class DTrackClient {
 			});
 	}
 
+	public Project getProject(UUID uuid) throws IOException {
+		URI uri = baseUri.resolve(API_PROJECT + "/" + uuid.toString());
+		HttpGet request = httpGet(uri);
+		return client.execute(request, responseBodyHandler(Project.class));
+	}
+
 	public Project getProject(String name) throws IOException {
 		URI uri = baseUri.resolve(API_PROJECT + "?name=" + name);
 		HttpGet request = httpGet(uri);

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Classifier.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Classifier.java
@@ -1,0 +1,17 @@
+package iabudiab.maven.plugins.dependencytrack.client.model;
+
+public enum Classifier {
+	NONE,
+	APPLICATION,
+	FRAMEWORK,
+	LIBRARY,
+	CONTAINER,
+	OPERATING_SYSTEM,
+	DEVICE,
+	FIRMWARE,
+	FILE,
+	PLATFORM,
+	DEVICE_DRIVER,
+	MACHINE_LEARNING_MODEL,
+	DATA
+}

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/CollectionLogic.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/CollectionLogic.java
@@ -1,0 +1,8 @@
+package iabudiab.maven.plugins.dependencytrack.client.model;
+
+public enum CollectionLogic {
+	NONE,
+	AGGREGATE_DIRECT_CHILDREN,
+	AGGREGATE_DIRECT_CHILDREN_WITH_TAG,
+	AGGREGATE_LATEST_VERSION_CHILDREN
+}

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
@@ -14,4 +14,12 @@ public class Project {
 	private String name;
 	private String version;
 	private Project parent;
+	private Classifier classifier;
+	private CollectionLogic collectionLogic;
+	private Tag collectionTag;
+
+	public Project() {
+		classifier = Classifier.NONE;
+		collectionLogic = CollectionLogic.NONE;
+	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Tag.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Tag.java
@@ -1,0 +1,15 @@
+package iabudiab.maven.plugins.dependencytrack.client.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Tag {
+	private String name;
+}

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
@@ -278,11 +278,11 @@ public class DTrack {
 
 	private static DTrackException handleCommonErrors(HttpResponseException e) {
 		if (e.getStatusCode() == 400) {
-			return new DTrackNotFoundException("Error uploading scan: " + e.getReasonPhrase(), e);
+			return new DTrackNotFoundException("Bad request: " + e.getReasonPhrase(), e);
 		} else if (e.getStatusCode() == 401) {
 			return new DTrackUnauthenticatedException("Unauthenticated: ", e);
 		} else {
-			return new DTrackException("Error uploading scan: ", e);
+			return new DTrackException("unexpected response: ", e);
 		}
 	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
@@ -109,6 +109,17 @@ public class DTrack {
 		}
 	}
 
+	public Project findProject(UUID uuid) throws DTrackException {
+		try {
+			return client.getProject(uuid);
+		} catch (HttpResponseException e) {
+			if(e.getStatusCode() == 404) return null;
+			else throw handleCommonErrors(e);
+		} catch (IOException e) {
+			throw new DTrackException("Error loading project: ", e);
+		}
+	}
+
 	public Project findProject(String projectName, String projectVersion) throws DTrackException {
 		try {
 			return client.getProject(projectName, projectVersion);

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
@@ -19,11 +19,13 @@ import iabudiab.maven.plugins.dependencytrack.client.model.Analysis;
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisJustification;
 import iabudiab.maven.plugins.dependencytrack.client.model.AnalysisResponse;
 import iabudiab.maven.plugins.dependencytrack.client.model.BomSubmitRequest;
+import iabudiab.maven.plugins.dependencytrack.client.model.CollectionLogic;
 import iabudiab.maven.plugins.dependencytrack.client.model.Finding;
 import iabudiab.maven.plugins.dependencytrack.client.model.Project;
 import iabudiab.maven.plugins.dependencytrack.client.model.ProjectMetrics;
 import iabudiab.maven.plugins.dependencytrack.client.model.ScanSubmitRequest;
 import iabudiab.maven.plugins.dependencytrack.client.model.State;
+import iabudiab.maven.plugins.dependencytrack.client.model.Tag;
 import iabudiab.maven.plugins.dependencytrack.client.model.TokenResponse;
 import iabudiab.maven.plugins.dependencytrack.cyclone.BomFormat;
 import iabudiab.maven.plugins.dependencytrack.suppressions.Suppression;
@@ -139,8 +141,12 @@ public class DTrack {
 	}
 
 	public Project createProject(String projectName, String projectVersion) throws DTrackException {
+		return createProject(projectName, projectVersion, null, null);
+	}
+
+	public Project createProject(String projectName, String projectVersion, CollectionLogic collectionLogic, Tag collectionTag) throws DTrackException {
 		try {
-			return client.createProject(projectName, projectVersion);
+			return client.createProject(projectName, projectVersion, collectionLogic, collectionTag);
 		} catch (HttpResponseException e) {
 			throw handleCommonErrors(e);
 		} catch (IOException e) {
@@ -155,6 +161,16 @@ public class DTrack {
 			throw handleCommonErrors(e);
 		} catch (IOException e) {
 			throw new DTrackException("Error applying parent: ", e);
+		}
+	}
+
+	public Project applyCollectionLogic(Project project, CollectionLogic collectionLogic, String collectionTag) {
+		try {
+			return client.applyCollectionLogic(project, collectionLogic, collectionTag);
+		} catch (HttpResponseException e) {
+			throw handleCommonErrors(e);
+		} catch (IOException e) {
+			throw new DTrackException("Error applying collection logic: ", e);
 		}
 	}
 


### PR DESCRIPTION
Hey @iabudiab,

since Dependency Track 4.13.0 there is a new feature called "Collection Projects", where parent projects can combine the metrics of its child projects.

With this Pull-Request I added some logic to be able to configure and apply the appropriate `collectionLogic` and `collectionTag` fields when uploading a bom file. So now you can either apply the parents collection logic when autocreating a parent (configuration `parentCollectionLogic` and  `parentCollectionTag`) or to set the collection logic of an aggregator project directly (configuration `collectionLogic` and `collectionTag`), either if this project has no actual bom file.

Please have a look at this ;)