### PR TITLE
URL encode project name and version parameters when looking up projects

### DIFF
--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/UploadBomMojo.java
@@ -297,7 +297,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 			boolean sameParentUuid = (parentUuid != null && parentUuid.equals(parentProject.getUuid()));
 			boolean sameParentNameAndVersion =
 				(parentName != null && parentName.equals(parentProject.getName())) &&
-				(parentVersion != null && parentVersion.equals(parentProject.getVersion()));
+				(parentVersion == null || parentVersion.equals(parentProject.getVersion()));
 
 			if (sameParentUuid || sameParentNameAndVersion) {
 				getLog().info(String.format("The parent '%s:%s' is already assigned, so no need to apply it again",

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -192,13 +194,13 @@ public class DTrackClient {
 	}
 
 	public Project getProject(String name) throws IOException {
-		URI uri = baseUri.resolve(API_PROJECT + "?name=" + name);
+		URI uri = baseUri.resolve(API_PROJECT + "?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8.name()));
 		HttpGet request = httpGet(uri);
 		return client.execute(request, responseBodyHandler(Project.class));
 	}
 
 	public Project getProject(String name, String version) throws IOException {
-		URI uri = baseUri.resolve(API_PROJECT_LOOKUP + "?name=" + name + "&version=" + version);
+		URI uri = baseUri.resolve(API_PROJECT_LOOKUP + "?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8.name()) + "&version=" + URLEncoder.encode(version, StandardCharsets.UTF_8.name()));
 		HttpGet request = httpGet(uri);
 		return client.execute(request, responseBodyHandler(Project.class));
 	}

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
@@ -196,10 +196,17 @@ public class DTrackClient {
 	public Project getProject(String name) throws IOException {
 		URI uri = baseUri.resolve(API_PROJECT + "?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8.name()));
 		HttpGet request = httpGet(uri);
-		return client.execute(request, responseBodyHandler(Project.class));
+		Project[] projects = client.execute(request, responseBodyHandler(Project[].class));
+
+		if(projects != null && projects.length > 0) return projects[0];
+		
+		return null;
 	}
 
 	public Project getProject(String name, String version) throws IOException {
+		// if no version is specified, delegate to finding project only by name
+		if(ObjectUtils.isEmpty(version)) return getProject(name);
+
 		URI uri = baseUri.resolve(API_PROJECT_LOOKUP + "?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8.name()) + "&version=" + URLEncoder.encode(version, StandardCharsets.UTF_8.name()));
 		HttpGet request = httpGet(uri);
 		return client.execute(request, responseBodyHandler(Project.class));


### PR DESCRIPTION
Hey @iabudiab,

I ran into the issue where looking up a project with a space in its name failed. So now I pass the project name and version to the URLEncoder's encode method before adding them to the URI string.

Looking forward for a new release ;)