### PR TITLE
optionally mark older projects inactive in dtrack server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,20 @@ Configuration:
 
 Uploads a CycloneDX or SPDX BOM to Dependency-Track. A project is created in Dependency-Track if it doesn't already exist.
 
-If both, `parentName` and `parentVersion` are specified (not empty), the appropriate parent project will be applied as a parent to the target project. If `autoCreateParent` is set to `true` and no matching parent project found in Dependency-Track, an appropriate parent project will be created first, otherwise the assigned parent project will be left as is. 
+If either `parentIdentifier` or both of `parentName` and `parentVersion` are specified (not empty), the appropriate parent project will be applied as a parent to the target project. If `autoCreateParent` is set to `true` and no matching parent project found in Dependency-Track, an appropriate parent project will be created first, otherwise the assigned parent project will be left as is. 
 
 Upon uploading a BOM to Dependency-Track a token is returned, which can be checked for processing status if `pollToken` is `true`.
 
 If `pollToken` is set to `false`, then this goal would upload the BOM, optionally assign the specified parent project, write the token to a file at `tokenFile` and then exit.
 
 Once the token is processed, the findings are available and can be fetched for further analysis.
+
+If `setOlderVersionsInactive` is set to `true` older versions (those that are lower than or equal) of this project will be set to `inactive` in Dependency-Track. To identify 'older' versions a three numbered version scheme (`[major-version].[minor-version].[patch-version]`, e.g. 3.11.8 or 1.2 or 2) is assumed and will be checked with an appropriate regex. If the version does not match that scheme, the corresponsing project version will be skipped. Here Older versions means all versions that have
+1. major-version less than current major-version or equal and
+2. minor-version less than current minor-version or equal and
+3. patch-version less than current patch-version
+
+When `ignoreVersionSuffixes` is set to true all suffixes to prior defined versioning scheme will be ignored when it comes to comparing the other projects version to the curent one. As a result, all versions with the same base versions will be set to "inactive", e.g. If we are releasing a version 1.2.3 all versions like 1.2.3-SNAPSHOT or 1.2.3-beta.2 will be set to "inactive" as well as all lower versions like 1.2.1 or 1.2 and so on.
 
 This goal polls Dependency-Track for `tokenPollingDuration`, which defaults to `60` seconds, then prints a findings report. The findings can be matched against a `security gate` in order to fail the build, which can be configured as follows:
 
@@ -211,6 +218,8 @@ Configuration:
 | `parentCollectionTag`        | The collection tag that should be applied to the created parent project             | empty                                                                         |
 | `collectionLogic`            | The collection logic that should be applied to the current project                  | empty                                                                         |
 | `collectionTag`              | The collection tag that should be applied to the current project                    | empty                                                                         |
+| `setOlderVersionsInactive`   | Whether or not set older versions of this project to 'inactive' in Dependency-Track | `false`                                                                       |
+| `ignoreVersionSuffixes`      | Whether or not ignore version suffixes when identifying old versions                | `true`                                                                        |
 
 ---
 

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/DTrackClient.java
@@ -252,14 +252,32 @@ public class DTrackClient {
 		return patchProject(project, payload);
 	}
 
+	public Project patchProjectActive(UUID projectUuid, boolean active, CollectionLogic collectionLogic, Tag collectionTag) throws IOException {
+		Map<String, Object> payload = new HashMap<>();
+
+		// TODO: remove, when the bug is fixed in dependency track api!
+		// due to a bug in dependency track, patching a project would reset the applied collectionLogic and collectionTags!
+		// so as a workaround we require to patch those values also!
+		payload.put("collectionLogic", collectionLogic);
+		payload.put("collectionTag", collectionTag);
+
+		payload.put("active", active);
+		return patchProject(projectUuid, payload);
+	}
+
 	public Project patchProject(Project project, Map<String, Object> payload) throws IOException {
-		URI uri = baseUri.resolve(API_PROJECT + "/" + project.getUuid().toString());
+		return patchProject(project.getUuid(), payload);
+	}
+
+
+	public Project patchProject(UUID projectUuid, Map<String, Object> payload) throws IOException {
+		URI uri = baseUri.resolve(API_PROJECT + "/" + projectUuid.toString());
 		String payloadAsString = objectMapper.writeValueAsString(payload);
 		HttpPatch request = httpPatch(uri, payloadAsString);
 
 		if (log.isDebugEnabled()) {
-			log.debug(String.format("Patching project '%s:%s' by applying payload: '%s'",
-				project.getName(), project.getVersion(), payloadAsString
+			log.debug(String.format("Patching project '%s' by applying payload: '%s'",
+				projectUuid.toString(), payloadAsString
 			));
 		}
 
@@ -268,11 +286,12 @@ public class DTrackClient {
 		if (log.isDebugEnabled()) {
 			log.debug(String.format(
 				"Successfully patched project '%s:%s' by applying payload: '%s'",
-				project.getName(), project.getVersion(), payloadAsString
+				response.getName(), response.getVersion(), payloadAsString
 			));
 		}
 		return response;
 	}
+
 
 	public Project postProject(Project project) throws IOException {
 		URI uri = baseUri.resolve(API_PROJECT);

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/Project.java
@@ -1,5 +1,6 @@
 package iabudiab.maven.plugins.dependencytrack.client.model;
 
+import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -17,9 +18,14 @@ public class Project {
 	private Classifier classifier;
 	private CollectionLogic collectionLogic;
 	private Tag collectionTag;
+	private Boolean isLatest;
+	private Boolean active;
+	private List<ProjectVersion> versions;
 
 	public Project() {
 		classifier = Classifier.NONE;
 		collectionLogic = CollectionLogic.NONE;
+		active = true;
+		isLatest = false;
 	}
 }

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/ProjectVersion.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/client/model/ProjectVersion.java
@@ -1,0 +1,17 @@
+package iabudiab.maven.plugins.dependencytrack.client.model;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectVersion {
+	
+	private UUID uuid;
+	private String version;
+	private Boolean active;
+
+}

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/dtrack/DTrack.java
@@ -366,6 +366,21 @@ public class DTrack {
 		}
 	}
 
+	public Project applyActive(UUID projectUuid, boolean active, CollectionLogic collectionLogic, Tag collectionTag) {
+		try {
+			Project updatedProject = client.patchProjectActive(projectUuid, active, collectionLogic, collectionTag);
+			log.info(String.format("Successfully applied active='%s' to project (uuid='%s')", active, projectUuid));
+			return updatedProject;
+		} catch (HttpResponseException e) {
+			log.error(String.format("Failed to apply active='%s' to project (uuid='%s'): %s", active, projectUuid, e.getMessage()), e);
+			throw handleCommonErrors(e);
+		} catch (IOException e) {
+			log.error(String.format("Failed to apply active='%s' to project (uuid='%s'): %s", active, projectUuid, e.getMessage()), e);
+			throw new DTrackException("Error applying active='"+ active +"' to project (uuid='"+ projectUuid +"')!", e);
+		}
+	}
+
+
 	/**
 	 * Polls a token for processing status in Dependency-Track.
 	 * <p>

--- a/src/main/java/iabudiab/maven/plugins/dependencytrack/util/VersionUtil.java
+++ b/src/main/java/iabudiab/maven/plugins/dependencytrack/util/VersionUtil.java
@@ -1,0 +1,59 @@
+package iabudiab.maven.plugins.dependencytrack.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Triple;
+
+public abstract class VersionUtil {
+
+	// create version regex pattern:
+	// ^ = beginning of the string
+	// \d+ = (required) one or more digits (major part)
+	// (?:\.\d+){0,2} = (optionally) dot separated minor and patch part
+	private static Pattern VERSION_PATTERN = Pattern.compile("^\\d+(?:\\.\\d+){0,2}");
+	
+	/**
+	 * parses a version string into comparable parts (major, minor, patch)
+	 * @param versionString the string that should be parsed
+	 * @return the three parsed parts as a {@link Triple}
+	 */
+	public static Triple<Integer, Integer, Integer> parseVersionString(String versionString, boolean ignoreVersionSuffixes) throws IllegalArgumentException {
+		
+		Matcher versionMatcher = VERSION_PATTERN.matcher(versionString);
+
+		// check if the projects version matches the pattern
+		// and cleanup current version, if ignoreVersionSuffixes is set to true
+		String cleanedVersion = versionString;
+		// if the string at least contains a match ...
+		if(versionMatcher.find()) {
+			// ... and ignore suffixes is set to true
+			if(ignoreVersionSuffixes) {
+				// extract that match
+				cleanedVersion = versionMatcher.group();
+			}
+			// ... and ignore suffixes is false but the string DOES contain any suffix
+			else if(!versionMatcher.matches()) {
+				throw new IllegalArgumentException(String.format(
+							"version '%s' does not exactly match expected version scheme (comma separated required major version and optional minor and patch versions)!"
+							+" Try setting 'ignoreVersionSuffixes' to 'true'.",
+							versionString
+						));
+			}
+		}
+		else {
+			throw new IllegalArgumentException(String.format(
+						"version '%s' does not start with expected version scheme (comma separated required major version and optional minor and patch versions)!",
+						versionString
+					));
+		}
+		
+		String[] versionParts = cleanedVersion.split("\\.");
+
+		Integer major = Integer.parseInt(versionParts[0]);
+		Integer minor = versionParts.length > 1 ? Integer.parseInt(versionParts[1]) : null;
+		Integer patch = versionParts.length > 2 ? Integer.parseInt(versionParts[2]) : null;
+		
+		return Triple.of(major, minor, patch);
+	}
+}

--- a/src/test/java/iabudiab/maven/plugins/dependencytrack/util/VersionUtilTest.java
+++ b/src/test/java/iabudiab/maven/plugins/dependencytrack/util/VersionUtilTest.java
@@ -1,0 +1,110 @@
+package iabudiab.maven.plugins.dependencytrack.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.jupiter.api.Test;
+
+
+public class VersionUtilTest {
+	
+	@Test
+	public void parseVersionString_testSuccessWithMatchingScheme() {
+		List<Pair<String, Triple<Integer, Integer, Integer>>> inputAndExpectedOutput = Arrays.asList(
+			Pair.of("0", Triple.of(0, null, null)),
+			Pair.of("0.0", Triple.of(0, 0, null)),
+			Pair.of("0.0.0", Triple.of(0, 0, 0)),
+			Pair.of("0.0.1", Triple.of(0, 0, 1)),
+			Pair.of("0.0.01", Triple.of(0, 0, 1)),
+			Pair.of("0.1.0", Triple.of(0, 1, 0)),
+			Pair.of("0.1.1", Triple.of(0, 1, 1)),
+			Pair.of("1", Triple.of(1, null, null)),
+			Pair.of("1.0", Triple.of(1, 0, null)),
+			Pair.of("1.0.0", Triple.of(1, 0, 0)),
+			Pair.of("1.2", Triple.of(1, 2, null)),
+			Pair.of("1.2.3", Triple.of(1, 2, 3)),
+			Pair.of("3.12.5", Triple.of(3, 12, 5))
+		);
+
+		for(Pair<String, Triple<Integer, Integer, Integer>> inOut : inputAndExpectedOutput) {
+			assertEquals(inOut.getRight(), VersionUtil.parseVersionString(inOut.getLeft(), false));
+		}
+	}
+
+	@Test
+	public void parseVersionString_testSuccessWithIgnoredSuffixes() {
+		List<Pair<String, Triple<Integer, Integer, Integer>>> inputAndExpectedOutput = Arrays.asList(
+			Pair.of("3-SNAPSHOT", Triple.of(3, null, null)),
+			Pair.of("3.12-SNAPSHOT", Triple.of(3, 12, null)),
+			Pair.of("3.12.5-SNAPSHOT", Triple.of(3, 12, 5)),
+			Pair.of("3.12.05-SNAPSHOT", Triple.of(3, 12, 5)),
+			Pair.of("3.12.5-beta.1", Triple.of(3, 12, 5)),
+			Pair.of("3.12.5.ALPHA-2", Triple.of(3, 12, 5)),
+			Pair.of("3.12.5.RELEASE", Triple.of(3, 12, 5)),
+			Pair.of("3.12.5.RC.3", Triple.of(3, 12, 5)),
+			Pair.of("3.", Triple.of(3, null, null)),
+			Pair.of("3..", Triple.of(3, null, null)),
+			Pair.of("3...", Triple.of(3, null, null)),
+			Pair.of("3..5", Triple.of(3, null, null)),
+			Pair.of("3..5.", Triple.of(3, null, null)),
+			Pair.of("3.12.5.", Triple.of(3, 12, 5)),
+			Pair.of("3.12.5a.", Triple.of(3, 12, 5)),
+			Pair.of("3.12.a5", Triple.of(3, 12, null)),
+			Pair.of("3.12a.5.", Triple.of(3, 12, null)),
+			Pair.of("3.a12.5", Triple.of(3, null, null)),
+			Pair.of("3a.12.5.", Triple.of(3, null, null))
+		);
+
+		for(Pair<String, Triple<Integer, Integer, Integer>> inOut : inputAndExpectedOutput) {
+			assertEquals(inOut.getRight(), VersionUtil.parseVersionString(inOut.getLeft(), true));
+		}
+	}
+
+
+	@Test
+	public void parseVersionString_testFail() {
+		List<String> inputVersions = Arrays.asList(
+			"3-SNAPSHOT",
+			"3.12-SNAPSHOT",
+			"3.12.5-SNAPSHOT",
+			"3.12.05-SNAPSHOT",
+			"3.12.5-beta.1",
+			"3.12.5.ALPHA-2",
+			"3.12.5.RELEASE",
+			"3.12.5.RC.3",
+			"3.",
+			"3..",
+			"3...",
+			"3..5",
+			"3..5.",
+			"3.12.5.",
+			"a.b.c",
+			"3.1a.5",
+			"3.12.5withsuffix"
+		);
+
+		for(String in : inputVersions) {
+			assertThrows(IllegalArgumentException.class, () -> VersionUtil.parseVersionString(in, false));
+		}
+	}
+
+
+	@Test
+	public void parseVersionString_testFailWithIgnoredSuffixes() {
+		List<String> inputVersions = Arrays.asList(
+			"a.b.c",
+			".3.1a.5",
+			"PREFIX-3.5.12"
+		);
+
+		for(String in : inputVersions) {
+			assertThrows(IllegalArgumentException.class, () -> VersionUtil.parseVersionString(in, true));
+		}
+	}
+	
+}


### PR DESCRIPTION
Hey @iabudiab,

i prepared a pull request, to optionally mark "older" versions of the uploading project as "inactive" when uploading a bom file.

You can activate it with a boolean configuration property, that is set to false by default. You can further configure the process by ignoring versions suffixes or not, that is also set to `false` by default.

Please take a look at this.

Best regards